### PR TITLE
Tolerate concurrent directory creation

### DIFF
--- a/writefile/writefile.go
+++ b/writefile/writefile.go
@@ -113,7 +113,9 @@ func (c Config) EnsureDirectoryIfNotExist() error {
 
 	// Parent now exists.
 	if err := os.Mkdir(c.Directory, c.getDirectoryMode()); err != nil {
-		return err
+		if !os.IsExist(err) {
+			return err
+		}
 	}
 
 	if c.EnsureDirectoryOwnership {


### PR DESCRIPTION
This fixes file failures during restore when more than one goroutine
tries to create the same parent directories for a file at the same time.