### PR TITLE
Have Travis cache go-build and modules

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,7 @@
 before:
   hooks:
     - go mod download
+    - go mod verify
     - go generate ./...
 builds:
   - env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 ---
 language: go
-go:
-  - "1.12.x"
+go: "1.12.x"
+cache:
+  directories:
+    - $HOME/.cache/go-build
+    - $HOME/gopath/pkg/mod
 env:
   global:
     - CGO_ENABLED=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ env:
   global:
     - CGO_ENABLED=0
     - GO111MODULE=on
-install: "go mod download"
+install:
+  - go mod download
+  - go mod verify
 deploy:
   - provider: script
     skip_cleanup: true


### PR DESCRIPTION
This should help avoid build failures due to Travis getting rate limited
by the module repos, as well as speed up builds.

Signed-off-by: Erik Swanson <erik@retailnext.net>