### PR TITLE
Improve incremental cleanup (BREAKING)

### DIFF
--- a/backup/finish.go
+++ b/backup/finish.go
@@ -49,7 +49,7 @@ func (p *processor) finish() error {
 			continue
 		}
 		if record.UploadError != nil && record.UploadError != bucket.UploadSkipped {
-			p.cleanupHandler.MarkUploadFailure(record.File.Name())
+			p.cleanupHandler.MarkUploadFailure(record.File)
 			lgr.Errorw("upload_error", "path", record.File.Name(), "err", record.UploadError)
 			hadFailures = true
 			if uploadError == nil {
@@ -66,7 +66,7 @@ func (p *processor) finish() error {
 			lgr.Panicw("duplicate_manifest_path", "record", record)
 		}
 		p.manifest.DataFiles[record.ManifestPath] = record.Digests.ForRestore()
-		p.cleanupHandler.MarkUploadSuccess(record.File.Name())
+		p.cleanupHandler.MarkUploadSuccess(record.File)
 	}
 
 	if hadFailures {

--- a/backup/incremental.go
+++ b/backup/incremental.go
@@ -23,7 +23,7 @@ import (
 	"context"
 )
 
-func DoIncremental(ctx context.Context, deleteIfSuccessful bool, cluster string) error {
+func DoIncremental(ctx context.Context, cluster string) error {
 	identity, manifest, err := systemlocal.GetIdentityAndSkeletonManifest(cluster, false)
 	if err != nil {
 		return err
@@ -44,12 +44,8 @@ func DoIncremental(ctx context.Context, deleteIfSuccessful bool, cluster string)
 
 		identity:       identity,
 		manifest:       manifest,
-		cleanupHandler: &dummyCleanupHandler{},
+		cleanupHandler: &incrementalCleanupHandler{},
 		pathProcessor:  incrementalPathProcessor{},
-	}
-
-	if deleteIfSuccessful {
-		pr.cleanupHandler = &incrementalCleanupHandler{}
 	}
 
 	go pr.prospect()

--- a/cassandrabackup.go
+++ b/cassandrabackup.go
@@ -111,13 +111,11 @@ var (
 	snapshotCmd        = kingpin.Command("snapshot", "Make a snapshot backup")
 	snapshotCmdCluster = snapshotCmd.Flag("backup.cluster", "Cluster name to back up as").Required().String()
 
-	incrementalCmd                  = kingpin.Command("incremental", "Back up incremental sstables")
-	incrementalCmdCluster           = incrementalCmd.Flag("backup.cluster", "Cluster name to back up as").Required().String()
-	incrementalCmdCleanIfSuccessful = incrementalCmd.Flag("backup.clean", "Remove incremental backup files that have been backed up").Bool()
+	incrementalCmd        = kingpin.Command("incremental", "Back up incremental sstables")
+	incrementalCmdCluster = incrementalCmd.Flag("backup.cluster", "Cluster name to back up as").Required().String()
 
-	runCmd                  = kingpin.Command("run", "Run as a daemon to back up periodically")
-	runCmdCluster           = runCmd.Flag("backup.cluster", "Cluster name to back up as").Required().String()
-	runCmdCleanIfSuccessful = runCmd.Flag("backup.clean", "Remove incremental backup files that have been backed up").Bool()
+	runCmd        = kingpin.Command("run", "Run as a daemon to back up periodically")
+	runCmdCluster = runCmd.Flag("backup.cluster", "Cluster name to back up as").Required().String()
 
 	restoreCmd                  = kingpin.Command("restore", "Restore from backup")
 	restoreCmdDryRun            = restoreCmd.Flag("restore.dry-run", "Don't actually download files").Bool()
@@ -169,7 +167,7 @@ func main() {
 			lgr.Fatalw("backup_error", "err", err)
 		}
 	case "incremental":
-		err := backup.DoIncremental(ctx, *incrementalCmdCleanIfSuccessful, *incrementalCmdCluster)
+		err := backup.DoIncremental(ctx, *incrementalCmdCluster)
 		if err == context.Canceled {
 			return
 		}
@@ -185,7 +183,7 @@ func main() {
 			lgr.Fatalw("restore_error", "err", err)
 		}
 	case "run":
-		err := periodic.Main(ctx, *runCmdCluster, *runCmdCleanIfSuccessful)
+		err := periodic.Main(ctx, *runCmdCluster)
 		if err == context.Canceled {
 			return
 		}

--- a/paranoid/file.go
+++ b/paranoid/file.go
@@ -47,6 +47,23 @@ func (f File) Len() int64 {
 	return f.fingerprint.size
 }
 
+// Remove a file only if it matches.
+// Returns a non-nil error if the file exits and doesn't match, or if os.Remove fails for a non-NotExist reason.
+func (f File) Delete() error {
+	err := f.Check()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	err = os.Remove(f.name)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
 func (f File) Check() error {
 	info, err := os.Stat(f.name)
 	if err != nil {

--- a/periodic/main.go
+++ b/periodic/main.go
@@ -25,7 +25,7 @@ import (
 const snapshotEvery = 1 * time.Hour
 const incrementalEvery = 5 * time.Minute
 
-func Main(ctx context.Context, cluster string, cleanIncremental bool) error {
+func Main(ctx context.Context, cluster string) error {
 	registerMetrics()
 	lgr := zap.S()
 
@@ -49,7 +49,7 @@ DONE:
 		if lastIncrementalAt.Before(now.Add(-incrementalEvery)) {
 			backupInProgressGauges.WithLabelValues("incremental").Set(1)
 			lgr.Infow("starting_backup", "type", "incremental")
-			err = backup.DoIncremental(ctx, cleanIncremental, cluster)
+			err = backup.DoIncremental(ctx, cluster)
 			backupInProgressGauges.WithLabelValues("incremental").Set(0)
 			now = time.Now()
 			if err == nil {


### PR DESCRIPTION
*   Replace `--backup.clean` with `--backup.clean.incremental`

    This will allow specific flags for automatically cleaning up
    dropped-CF snapshots, old auto-* snapshots, etc...

*   Log less when removing incremental cleanups.

*   Only remove files that match the uploaded mtime.

Signed-off-by: Erik Swanson <erik@retailnext.net>