### PR TITLE
Fix zero-timestamp backups

### DIFF
--- a/nodeidentity/identity.go
+++ b/nodeidentity/identity.go
@@ -18,6 +18,7 @@ import (
 	"cassandrabackup/cassandraconfig"
 	"cassandrabackup/manifests"
 	"cassandrabackup/systemlocal"
+	"cassandrabackup/unixtime"
 	"os"
 
 	"go.uber.org/zap"
@@ -63,6 +64,7 @@ func GetIdentityAndManifestTemplateOffline(overrideCluster, overrideHostname *st
 	}
 
 	template := manifests.Manifest{
+		Time:        unixtime.Now(),
 		Address:     cfg.IPForClients(),
 		Partitioner: cfg.Partitioner,
 		Tokens:      cfg.Tokens(),


### PR DESCRIPTION
Previous change included an incomplete transition to having the template
function set the time on the manifest template: only the reliance on
that was committed. The template now correctly has the time set.

Signed-off-by: Erik Swanson <erik@retailnext.net>