### PR TITLE
refactor: Align module name (/path) with VCS

### DIFF
--- a/backup/cleanup.go
+++ b/backup/cleanup.go
@@ -15,9 +15,8 @@
 package backup
 
 import (
-	"cassandrabackup/nodetool"
-	"cassandrabackup/paranoid"
-
+	"github.com/retailnext/cassandrabackup/nodetool"
+	"github.com/retailnext/cassandrabackup/paranoid"
 	"go.uber.org/zap"
 )
 

--- a/backup/finish.go
+++ b/backup/finish.go
@@ -15,11 +15,11 @@
 package backup
 
 import (
-	"cassandrabackup/bucket"
-	"cassandrabackup/digest"
-	"cassandrabackup/manifests"
 	"context"
 
+	"github.com/retailnext/cassandrabackup/bucket"
+	"github.com/retailnext/cassandrabackup/digest"
+	"github.com/retailnext/cassandrabackup/manifests"
 	"go.uber.org/zap"
 )
 

--- a/backup/incremental.go
+++ b/backup/incremental.go
@@ -15,11 +15,12 @@
 package backup
 
 import (
-	"cassandrabackup/bucket"
-	"cassandrabackup/digest"
-	"cassandrabackup/manifests"
-	"cassandrabackup/nodeidentity"
 	"context"
+
+	"github.com/retailnext/cassandrabackup/bucket"
+	"github.com/retailnext/cassandrabackup/digest"
+	"github.com/retailnext/cassandrabackup/manifests"
+	"github.com/retailnext/cassandrabackup/nodeidentity"
 )
 
 func DoIncremental(ctx context.Context) error {

--- a/backup/processor.go
+++ b/backup/processor.go
@@ -15,11 +15,12 @@
 package backup
 
 import (
-	"cassandrabackup/bucket"
-	"cassandrabackup/digest"
-	"cassandrabackup/manifests"
-	"cassandrabackup/paranoid"
 	"context"
+
+	"github.com/retailnext/cassandrabackup/bucket"
+	"github.com/retailnext/cassandrabackup/digest"
+	"github.com/retailnext/cassandrabackup/manifests"
+	"github.com/retailnext/cassandrabackup/paranoid"
 )
 
 type processor struct {

--- a/backup/prospect.go
+++ b/backup/prospect.go
@@ -15,11 +15,11 @@
 package backup
 
 import (
-	"cassandrabackup/paranoid"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/retailnext/cassandrabackup/paranoid"
 	"go.uber.org/zap"
 )
 

--- a/backup/snapshot.go
+++ b/backup/snapshot.go
@@ -15,13 +15,14 @@
 package backup
 
 import (
-	"cassandrabackup/bucket"
-	"cassandrabackup/digest"
-	"cassandrabackup/manifests"
-	"cassandrabackup/nodeidentity"
-	"cassandrabackup/nodetool"
 	"context"
 	"fmt"
+
+	"github.com/retailnext/cassandrabackup/bucket"
+	"github.com/retailnext/cassandrabackup/digest"
+	"github.com/retailnext/cassandrabackup/manifests"
+	"github.com/retailnext/cassandrabackup/nodeidentity"
+	"github.com/retailnext/cassandrabackup/nodetool"
 )
 
 func DoSnapshotBackup(ctx context.Context) error {

--- a/backup/upload.go
+++ b/backup/upload.go
@@ -15,10 +15,10 @@
 package backup
 
 import (
-	"cassandrabackup/bucket"
 	"context"
 	"sync"
 
+	"github.com/retailnext/cassandrabackup/bucket"
 	"go.uber.org/zap"
 )
 

--- a/bucket/blob.go
+++ b/bucket/blob.go
@@ -15,8 +15,6 @@
 package bucket
 
 import (
-	"cassandrabackup/digest"
-	"cassandrabackup/paranoid"
 	"context"
 	"errors"
 	"io"
@@ -24,6 +22,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/retailnext/cassandrabackup/digest"
+	"github.com/retailnext/cassandrabackup/paranoid"
 	"go.uber.org/zap"
 )
 

--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -15,8 +15,6 @@
 package bucket
 
 import (
-	"cassandrabackup/bucket/safeuploader"
-	"cassandrabackup/cache"
 	"strings"
 	"sync"
 	"time"
@@ -27,6 +25,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
+	"github.com/retailnext/cassandrabackup/bucket/safeuploader"
+	"github.com/retailnext/cassandrabackup/cache"
 	"go.uber.org/zap"
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/bucket/existscache.go
+++ b/bucket/existscache.go
@@ -15,12 +15,12 @@
 package bucket
 
 import (
-	"cassandrabackup/cache"
-	"cassandrabackup/digest"
-	"cassandrabackup/unixtime"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/retailnext/cassandrabackup/cache"
+	"github.com/retailnext/cassandrabackup/digest"
+	"github.com/retailnext/cassandrabackup/unixtime"
 	"go.uber.org/zap"
 )
 
@@ -75,14 +75,12 @@ func (e *ExistsCache) Put(restore digest.ForRestore, lockedUntil time.Time) {
 	}
 }
 
-var (
-	existsCacheLockTimeMisses = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "cassandrabackup",
-		Subsystem: "bucket_exists_cache",
-		Name:      "lock_time_misses_total",
-		Help:      "Number of exists cache misses due to expired/future lock time.",
-	})
-)
+var existsCacheLockTimeMisses = prometheus.NewCounter(prometheus.CounterOpts{
+	Namespace: "cassandrabackup",
+	Subsystem: "bucket_exists_cache",
+	Name:      "lock_time_misses_total",
+	Help:      "Number of exists cache misses due to expired/future lock time.",
+})
 
 func init() {
 	prometheus.MustRegister(existsCacheLockTimeMisses)

--- a/bucket/keys.go
+++ b/bucket/keys.go
@@ -15,14 +15,14 @@
 package bucket
 
 import (
-	"cassandrabackup/digest"
-	"cassandrabackup/manifests"
-	"cassandrabackup/unixtime"
 	"encoding/base64"
 	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/retailnext/cassandrabackup/digest"
+	"github.com/retailnext/cassandrabackup/manifests"
+	"github.com/retailnext/cassandrabackup/unixtime"
 )
 
 func (c *Client) keyWithPrefix(key string) string {

--- a/bucket/manifests.go
+++ b/bucket/manifests.go
@@ -15,13 +15,13 @@
 package bucket
 
 import (
-	"cassandrabackup/manifests"
-	"cassandrabackup/unixtime"
 	"context"
 	"path/filepath"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/retailnext/cassandrabackup/manifests"
+	"github.com/retailnext/cassandrabackup/unixtime"
 	"go.uber.org/zap"
 )
 

--- a/bucket/nodes.go
+++ b/bucket/nodes.go
@@ -15,11 +15,11 @@
 package bucket
 
 import (
-	"cassandrabackup/manifests"
 	"context"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/retailnext/cassandrabackup/manifests"
 	"go.uber.org/zap"
 )
 

--- a/bucket/safeuploader/safeuploader.go
+++ b/bucket/safeuploader/safeuploader.go
@@ -15,8 +15,6 @@
 package safeuploader
 
 import (
-	"cassandrabackup/digest"
-	"cassandrabackup/paranoid"
 	"context"
 	"fmt"
 	"io"
@@ -27,6 +25,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/retailnext/cassandrabackup/digest"
+	"github.com/retailnext/cassandrabackup/paranoid"
 	"go.uber.org/zap"
 )
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -227,7 +227,7 @@ func (c *Cache) put(key, value []byte) error {
 }
 
 func (s *Storage) currentAndPreviousTopBuckets() ([]byte, []byte) {
-	var now = time.Now().Unix()
+	now := time.Now().Unix()
 	currentTs := (now / s.bucketPeriod) * s.bucketPeriod
 	previousTs := currentTs - s.bucketPeriod
 

--- a/cassandrabackup.go
+++ b/cassandrabackup.go
@@ -15,13 +15,6 @@
 package main
 
 import (
-	"cassandrabackup/backup"
-	"cassandrabackup/bucket"
-	"cassandrabackup/cache"
-	"cassandrabackup/manifests"
-	"cassandrabackup/periodic"
-	"cassandrabackup/restore"
-	"cassandrabackup/unixtime"
 	"context"
 	"net/http"
 	"os"
@@ -29,6 +22,13 @@ import (
 	"runtime/pprof"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/retailnext/cassandrabackup/backup"
+	"github.com/retailnext/cassandrabackup/bucket"
+	"github.com/retailnext/cassandrabackup/cache"
+	"github.com/retailnext/cassandrabackup/manifests"
+	"github.com/retailnext/cassandrabackup/periodic"
+	"github.com/retailnext/cassandrabackup/restore"
+	"github.com/retailnext/cassandrabackup/unixtime"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh/terminal"
 	"gopkg.in/alecthomas/kingpin.v2"

--- a/cassandraconfig/raw.go
+++ b/cassandraconfig/raw.go
@@ -15,11 +15,11 @@
 package cassandraconfig
 
 import (
-	"cassandrabackup/paranoid"
 	"sort"
 	"strings"
 	"sync"
 
+	"github.com/retailnext/cassandrabackup/paranoid"
 	"gopkg.in/yaml.v2"
 )
 

--- a/digest/cache.go
+++ b/digest/cache.go
@@ -15,12 +15,12 @@
 package digest
 
 import (
-	"cassandrabackup/cache"
-	"cassandrabackup/paranoid"
 	"context"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/retailnext/cassandrabackup/cache"
+	"github.com/retailnext/cassandrabackup/paranoid"
 )
 
 type Cache struct {

--- a/digest/cache_test.go
+++ b/digest/cache_test.go
@@ -15,13 +15,14 @@
 package digest
 
 import (
-	"cassandrabackup/cache"
-	"cassandrabackup/paranoid"
 	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/retailnext/cassandrabackup/cache"
+	"github.com/retailnext/cassandrabackup/paranoid"
 )
 
 func TestCache(t *testing.T) {

--- a/digest/forupload.go
+++ b/digest/forupload.go
@@ -15,13 +15,13 @@
 package digest
 
 import (
-	"cassandrabackup/digest/parts"
-	"cassandrabackup/paranoid"
 	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
 
+	"github.com/retailnext/cassandrabackup/digest/parts"
+	"github.com/retailnext/cassandrabackup/paranoid"
 	"golang.org/x/crypto/blake2b"
 )
 

--- a/digest/uncached.go
+++ b/digest/uncached.go
@@ -15,8 +15,9 @@
 package digest
 
 import (
-	"cassandrabackup/paranoid"
 	"context"
+
+	"github.com/retailnext/cassandrabackup/paranoid"
 )
 
 func GetUncached(ctx context.Context, file paranoid.File) (ForUpload, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module cassandrabackup
+module github.com/retailnext/cassandrabackup
 
 require (
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect

--- a/manifests/key.go
+++ b/manifests/key.go
@@ -15,11 +15,12 @@
 package manifests
 
 import (
-	"cassandrabackup/unixtime"
 	"errors"
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/retailnext/cassandrabackup/unixtime"
 )
 
 var InvalidManifestKey = errors.New("invalid manifest key")

--- a/manifests/manifest.go
+++ b/manifests/manifest.go
@@ -15,8 +15,8 @@
 package manifests
 
 import (
-	"cassandrabackup/digest"
-	"cassandrabackup/unixtime"
+	"github.com/retailnext/cassandrabackup/digest"
+	"github.com/retailnext/cassandrabackup/unixtime"
 )
 
 type ManifestType int

--- a/manifests/manifest_easyjson.go
+++ b/manifests/manifest_easyjson.go
@@ -3,11 +3,12 @@
 package manifests
 
 import (
-	digest "cassandrabackup/digest"
 	json "encoding/json"
+
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
+	digest "github.com/retailnext/cassandrabackup/digest"
 )
 
 // suppress unused package warning

--- a/manifests/manifest_test.go
+++ b/manifests/manifest_test.go
@@ -15,9 +15,6 @@
 package manifests
 
 import (
-	"cassandrabackup/digest"
-	"cassandrabackup/paranoid"
-	"cassandrabackup/unixtime"
 	"context"
 	"crypto/rand"
 	"io/ioutil"
@@ -26,6 +23,9 @@ import (
 
 	"github.com/go-test/deep"
 	"github.com/mailru/easyjson"
+	"github.com/retailnext/cassandrabackup/digest"
+	"github.com/retailnext/cassandrabackup/paranoid"
+	"github.com/retailnext/cassandrabackup/unixtime"
 )
 
 func TestManifest(t *testing.T) {

--- a/nodeidentity/identity.go
+++ b/nodeidentity/identity.go
@@ -15,12 +15,12 @@
 package nodeidentity
 
 import (
-	"cassandrabackup/cassandraconfig"
-	"cassandrabackup/manifests"
-	"cassandrabackup/systemlocal"
-	"cassandrabackup/unixtime"
 	"os"
 
+	"github.com/retailnext/cassandrabackup/cassandraconfig"
+	"github.com/retailnext/cassandrabackup/manifests"
+	"github.com/retailnext/cassandrabackup/systemlocal"
+	"github.com/retailnext/cassandrabackup/unixtime"
 	"go.uber.org/zap"
 )
 

--- a/nodeidentity/restore.go
+++ b/nodeidentity/restore.go
@@ -15,13 +15,13 @@
 package nodeidentity
 
 import (
-	"cassandrabackup/bucket"
-	"cassandrabackup/cassandraconfig"
-	"cassandrabackup/manifests"
 	"context"
 	"regexp"
 	"strings"
 
+	"github.com/retailnext/cassandrabackup/bucket"
+	"github.com/retailnext/cassandrabackup/cassandraconfig"
+	"github.com/retailnext/cassandrabackup/manifests"
 	"go.uber.org/zap"
 )
 

--- a/paranoid/file.go
+++ b/paranoid/file.go
@@ -14,9 +14,7 @@
 
 package paranoid
 
-import (
-	"os"
-)
+import "os"
 
 func NewFileFromInfo(name string, info os.FileInfo) File {
 	file := File{

--- a/paranoid/mismatch.go
+++ b/paranoid/mismatch.go
@@ -14,9 +14,7 @@
 
 package paranoid
 
-import (
-	"fmt"
-)
+import "fmt"
 
 type FingerprintMismatch struct {
 	name     string

--- a/periodic/main.go
+++ b/periodic/main.go
@@ -15,10 +15,10 @@
 package periodic
 
 import (
-	"cassandrabackup/backup"
 	"context"
 	"time"
 
+	"github.com/retailnext/cassandrabackup/backup"
 	"go.uber.org/zap"
 )
 

--- a/restore/plan.go
+++ b/restore/plan.go
@@ -15,14 +15,14 @@
 package restore
 
 import (
-	"cassandrabackup/bucket"
-	"cassandrabackup/digest"
-	"cassandrabackup/manifests"
-	"cassandrabackup/nodeidentity"
-	"cassandrabackup/unixtime"
 	"context"
 	"errors"
 
+	"github.com/retailnext/cassandrabackup/bucket"
+	"github.com/retailnext/cassandrabackup/digest"
+	"github.com/retailnext/cassandrabackup/manifests"
+	"github.com/retailnext/cassandrabackup/nodeidentity"
+	"github.com/retailnext/cassandrabackup/unixtime"
 	"go.uber.org/zap"
 )
 
@@ -75,7 +75,7 @@ func selectManifests(ctx context.Context, identity manifests.NodeIdentity, start
 		return nil, err
 	}
 
-	var snapshotIndex = -1
+	snapshotIndex := -1
 	for i := len(keys) - 1; i >= 0; i-- {
 		if keys[i].ManifestType == manifests.ManifestTypeSnapshot {
 			snapshotIndex = i

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -15,11 +15,6 @@
 package restore
 
 import (
-	"cassandrabackup/bucket"
-	"cassandrabackup/digest"
-	"cassandrabackup/manifests"
-	"cassandrabackup/paranoid"
-	"cassandrabackup/writefile"
 	"context"
 	"os"
 	"os/user"
@@ -29,6 +24,11 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/retailnext/cassandrabackup/bucket"
+	"github.com/retailnext/cassandrabackup/digest"
+	"github.com/retailnext/cassandrabackup/manifests"
+	"github.com/retailnext/cassandrabackup/paranoid"
+	"github.com/retailnext/cassandrabackup/writefile"
 	"go.uber.org/zap"
 )
 


### PR DESCRIPTION
BREAKING CHANGE: The import/module path has been changed to
`github.com/retailnext/cassandrabackup`.

Having a module name with no dots in the leading name isn't valid.

(Also, run gofumpt.)

Signed-off-by: Erik Swanson <erik@retailnext.net>