### PR TITLE
chore(ci): Disable Travis caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 ---
 language: go
 go: "1.13.x"
-cache:
-  directories:
-    - $HOME/.cache/go-build
-    - $HOME/gopath/pkg/mod
 env:
   global:
     - CGO_ENABLED=0


### PR DESCRIPTION
This should hopefully fix builds hanging on
`creating directory /home/travis/gopath/pkg/mod`.

Signed-off-by: Erik Swanson <erik@retailnext.net>