### PR TITLE
chore(ci): Limit branch builds to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 ---
 language: go
 go: "1.13.x"
+branches:
+  only:
+    - master
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 env:
   global:
     - CGO_ENABLED=0


### PR DESCRIPTION
Skip "branch" builds in Travis except for the master branch and
version tags.