### PR TITLE
chore(ci): Update goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,16 +11,18 @@ builds:
       - linux
     goarch:
       - amd64
-nfpm:
-  formats:
-    - deb
-  homepage: "https://github.com/retailnext/cassandrabackup"
-  license: "Apache 2.0"
+nfpms:
+  - formats:
+      - deb
+    homepage: "https://github.com/retailnext/cassandrabackup"
+    license: "Apache 2.0"
 checksum:
   name_template: 'checksums.txt'
 changelog:
   sort: asc
   filters:
     exclude:
+      - '^chore(ci):'
+      - '^chore(deps):'
       - '^docs:'
       - '^test:'


### PR DESCRIPTION
*   Change `nfpm` to `nfpms` (array)

    Goreleaser dropped support for the singular form at some point.

*   Exclude `chore(ci)` and `chore(deps)` from changelog.

    This will make the changelog usable by keeping the meaningful
    changes from being buried under hundreds of Renovate updates.