### PR TITLE
chore(ci): Fix goreleaser changelog config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,7 +22,7 @@ changelog:
   sort: asc
   filters:
     exclude:
-      - '^chore(ci):'
-      - '^chore(deps):'
+      - '^chore\(ci\):'
+      - '^chore\(deps\):'
       - '^docs:'
       - '^test:'


### PR DESCRIPTION
Fix exclusion of `chore(ci):` and `chore(deps):` commits.

Signed-off-by: Erik Swanson <erik@retailnext.net>